### PR TITLE
Add radio button field to PageFieldScreen

### DIFF
--- a/example/lib/fiels/page_field_screen.dart
+++ b/example/lib/fiels/page_field_screen.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_form_builder/flutter_form_builder.dart';
 import 'package:schoolap_ui/schoolap_ui.dart';
 
 class PageFieldScreen extends StatelessWidget {
@@ -67,6 +68,10 @@ class PageFieldScreen extends StatelessWidget {
               prefix: Icon(Icons.date_range),
             ),
             const SizedBox(height: 20),
+            const SPRadio(name: "radio", options: [
+              FormBuilderFieldOption(value: 1, child: Text("One")),
+              FormBuilderFieldOption(value: 2, child: Text("Two")),
+            ])
           ],
         ),
       ),

--- a/lib/src/widgets/app_field/schoolap_radio.dart
+++ b/lib/src/widgets/app_field/schoolap_radio.dart
@@ -1,0 +1,35 @@
+part of '../widget.dart';
+
+typedef FormBuilderFieldOptionList<T> = List<FormBuilderFieldOption<T>>;
+
+class SPRadio<T> extends StatelessWidget {
+  final String name;
+  final String? label;
+  final FormBuilderFieldOptionList<T> options;
+  const SPRadio(
+      {super.key, this.label, required this.name, required this.options});
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      children: [
+        if (label != null)
+          Padding(
+            padding: const EdgeInsets.symmetric(vertical: 10),
+            child: Text(
+              label!,
+              style: const TextStyle(
+                fontSize: 14.0,
+                fontFamily: 'Poppins',
+                fontWeight: FontWeight.w600,
+              ),
+            ),
+          ),
+        FormBuilderCheckboxGroup<T>(
+          name: name,
+          options: options,
+        )
+      ],
+    );
+  }
+}

--- a/lib/src/widgets/widget.dart
+++ b/lib/src/widgets/widget.dart
@@ -24,3 +24,4 @@ part 'card/schoolap_card_tile.dart';
 part 'card/schoolap_card_with_image.dart';
 part 'card/schoolap_pop_menu_button.dart';
 part 'card/custom_pop_up.dart';
+part 'app_field/schoolap_radio.dart';


### PR DESCRIPTION
- Imported the "SPRadio" class from the "schoolap_radio.dart" file.
- Added a radio button field to the PageFieldScreen widget, labeled as "radio" with two options: "One" and "Two".